### PR TITLE
feature/grid_griditem > Grid and GridItem component added

### DIFF
--- a/src/components/Grid.js
+++ b/src/components/Grid.js
@@ -1,0 +1,38 @@
+import * as React from "react";
+import styled from "styled-components";
+import PropTypes from "prop-types";
+
+const GridEl = styled.div`
+  display: grid;
+  width: 100%;
+  height: 100%;
+  grid-template-columns: ${(props) => props.templateColumns};
+  grid-gap: ${(props) => props.gap};
+`;
+
+const Grid = React.forwardRef(function Grid(
+  { children, templateColumns, gap, ...props },
+  ref,
+) {
+  return (
+    <GridEl ref={ref} templateColumns={templateColumns} gap={gap} {...props}>
+      {children}
+    </GridEl>
+  );
+});
+
+Grid.propTypes = {
+  /**
+   * Sets the 'grid-template-columns'
+   */
+  templateColumns: PropTypes.string,
+  /**
+   * Gap of the grid. A shorthand for 'grid-row-gap' and 'grid-column-gap'
+   * For example, 'grid-gap: 15px 10px;' will have gap of 15px between the rows 10px between the columns
+   */
+  gap: PropTypes.string,
+  children: PropTypes.node.isRequired,
+};
+
+/** @component */
+export default Grid;

--- a/src/components/Grid.md
+++ b/src/components/Grid.md
@@ -1,0 +1,101 @@
+3 Column Grid Example with 20px grid gap of top/bottom and 10px grid gap of
+left/right
+
+```jsx
+import Grid from "./Grid";
+import GridItem from "./GridItem";
+
+<Grid templateColumns="repeat(3, 1fr)" gap="20px 10px">
+  <GridItem style={{ padding: "10px", border: "1px solid #000" }}>
+    Column 1
+  </GridItem>
+  <GridItem style={{ padding: "10px", border: "1px solid #000" }}>
+    Column 2
+  </GridItem>
+  <GridItem style={{ padding: "10px", border: "1px solid #000" }}>
+    Column 3
+  </GridItem>
+  <GridItem style={{ padding: "10px", border: "1px solid #000" }}>
+    Column 1
+  </GridItem>
+  <GridItem style={{ padding: "10px", border: "1px solid #000" }}>
+    Column 2
+  </GridItem>
+  <GridItem style={{ padding: "10px", border: "1px solid #000" }}>
+    Column 3
+  </GridItem>
+</Grid>;
+```
+
+2 Column Grid Example with 25px grid gap
+
+```jsx
+import Grid from "./Grid";
+import GridItem from "./GridItem";
+
+<Grid templateColumns="repeat(2, 1fr)" gap="25px">
+  <GridItem style={{ padding: "10px", border: "1px solid #000" }}>
+    Column 1
+  </GridItem>
+  <GridItem style={{ padding: "10px", border: "1px solid #000" }}>
+    Column 2
+  </GridItem>
+  <GridItem style={{ padding: "10px", border: "1px solid #000" }}>
+    Column 1
+  </GridItem>
+  <GridItem style={{ padding: "10px", border: "1px solid #000" }}>
+    Column 2
+  </GridItem>
+  <GridItem style={{ padding: "10px", border: "1px solid #000" }}>
+    Column 1
+  </GridItem>
+  <GridItem style={{ padding: "10px", border: "1px solid #000" }}>
+    Column 2
+  </GridItem>
+</Grid>;
+```
+
+Above examples do not explicitly place `<GridItem />` on the grid, which means
+the auto-placement algorithm kicks in to automatically place the items. In order
+to fill in each row and column, use `column` and `row` props on `<GridItem />`.
+
+```jsx
+import Grid from "./Grid";
+import GridItem from "./GridItem";
+
+<Grid templateColumns="repeat(4, 1fr)" gap="15px">
+  <GridItem
+    column="1 / 3"
+    row="1 / 3"
+    style={{
+      padding: "10px",
+      backgroundColor: "#FFE5B4",
+    }}
+  >
+    column="1 / 3"
+    <br />
+    row="1 / 3"
+  </GridItem>
+  <GridItem
+    column="3 / 5"
+    style={{ padding: "10px", backgroundColor: "#E6E6FA" }}
+  >
+    column="3 / 5"
+  </GridItem>
+  <GridItem style={{ padding: "10px", border: "1px solid #000" }}>
+    (no props)
+  </GridItem>
+  <GridItem style={{ padding: "10px", border: "1px solid #000" }}>
+    (no props)
+  </GridItem>
+  <GridItem
+    column="1 / 4"
+    style={{ padding: "10px", backgroundColor: "#F5F5DC" }}
+  >
+    column="1 / 4"
+  </GridItem>
+  <GridItem style={{ padding: "10px", border: "1px solid #000" }}>
+    (no props)
+  </GridItem>
+</Grid>;
+```

--- a/src/components/GridItem.js
+++ b/src/components/GridItem.js
@@ -1,0 +1,32 @@
+import * as React from "react";
+import styled from "styled-components";
+import PropTypes from "prop-types";
+
+const GridItemEl = styled.div`
+  display: flex;
+  grid-column: ${(props) => props.column};
+  grid-row: ${(props) => props.row};
+`;
+
+const GridItem = React.forwardRef(function GridItem(
+  { column, row, ...props },
+  ref,
+) {
+  return <GridItemEl ref={ref} column={column} row={row} {...props} />;
+});
+
+GridItem.propTypes = {
+  /**
+   * For 'grid-column' attribute
+   * Tells the auto-placement algorithm to fill in each column in turn, adding new columns as necessary
+   */
+  column: PropTypes.string,
+  /**
+   * * For 'grid-row' attribute
+   * Tells the auto-placement algorithm to fill in each row in turn, adding new rows as necessary (default)
+   */
+  row: PropTypes.string,
+};
+
+/** @component */
+export default GridItem;

--- a/src/components/GridItem.md
+++ b/src/components/GridItem.md
@@ -1,0 +1,1 @@
+See [Grid](/#/Web?id=grid) for `<GridItem />` example

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -18,6 +18,14 @@ module.exports = {
           usageMode: "expand",
         },
         {
+          name: "Layout",
+          components: () => [
+            "src/components/Grid.js",
+            "src/components/GridItem.js",
+          ],
+          usageMode: "expand",
+        },
+        {
           name: "Components",
           components: () => [
             "src/components/BulletedList.js",


### PR DESCRIPTION
* Didn't include many that props on purpose since flexibility is a key for CSS Grid
* `Grid.js`
-- For stellar.org, `grid-template-columns` and `grid-gap` attributes were handy so added that as props.
* `GridItem.js`
-- Allowed props for `grid-column` and `grid-row` for expanding columns and rows