### PR TITLE
feature/code_example > <Table/> and <CodeExample/> added

### DIFF
--- a/src/components/CodeExample.js
+++ b/src/components/CodeExample.js
@@ -1,0 +1,57 @@
+import * as React from "react";
+import styled from "styled-components";
+import PropTypes from "prop-types";
+
+import { PALETTE, FONT_WEIGHT } from "../shared";
+
+const CodeExampleEl = styled.div`
+  display: flex;
+  flex-direction: column;
+  padding: 0 1.5rem;
+  background: ${(props) =>
+    props.isCodeSnippet ? PALETTE.black90 : PALETTE.white80};
+`;
+
+const TitleEl = styled.div`
+  position: relative;
+  padding: 0;
+  padding-top: 1.5rem;
+  padding-bottom: 1rem;
+  border-bottom: 1px solid ${PALETTE.white60};
+  font-size: 0.875rem;
+  font-weight: ${FONT_WEIGHT.medium};
+`;
+const ContentEl = styled.div`
+  padding: 1rem 0;
+`;
+
+/**
+ * Note: This exports a React component instead of a styled-component.
+ * [Design Mockup](https://zpl.io/V1DGqJ5)
+ */
+
+const CodeExample = React.forwardRef(function CodeExample(
+  { title, children, ...props },
+  ref,
+) {
+  return (
+    <CodeExampleEl ref={ref} {...props}>
+      <TitleEl>{title}</TitleEl>
+      <ContentEl>{children}</ContentEl>
+    </CodeExampleEl>
+  );
+});
+
+CodeExample.propTypes = {
+  /**
+   * The title of the card
+   */
+  title: PropTypes.node.isRequired,
+  /**
+   * The copy of the card
+   */
+  children: PropTypes.node.isRequired,
+};
+
+/** @component */
+export default CodeExample;

--- a/src/components/CodeExample.md
+++ b/src/components/CodeExample.md
@@ -1,0 +1,35 @@
+CodeExample - Endpoints
+
+```jsx
+import Table from "./Table";
+import { PALETTE } from "../shared";
+
+<CodeExample title="Endpoints">
+  <Table hasCodeFormat customColor={PALETTE.purple}>
+    <tr>
+      <th>
+        <span>GET</span>
+      </th>
+      <td>
+        <span>/operations/:operation_id</span>
+      </td>
+    </tr>
+    <tr>
+      <th>
+        <span>GET</span>
+      </th>
+      <td>
+        <span>/operations/:operation_id/effects</span>
+      </td>
+    </tr>
+    <tr>
+      <th>
+        <span>GET</span>
+      </th>
+      <td>
+        <span>/operations{"{?cursor,limit,order,include_failed}"}</span>
+      </td>
+    </tr>
+  </Table>
+</CodeExample>;
+```

--- a/src/components/GlobalStyle.js
+++ b/src/components/GlobalStyle.js
@@ -8,7 +8,7 @@ const GlobalStyle = createGlobalStyle`
   html {
     font-family: 'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif;
     font-size: 16px;
-    line-height: 28px;
+    line-height: normal;
     letter-spacing: normal;
   }
 

--- a/src/components/Table.js
+++ b/src/components/Table.js
@@ -1,0 +1,92 @@
+import * as React from "react";
+import styled from "styled-components";
+import PropTypes from "prop-types";
+import { PALETTE, FONT_FAMILY, FONT_WEIGHT } from "../shared";
+
+const TableEl = styled.table`
+  width: 100%;
+  padding: 0;
+  margin: 0;
+  font-size: 0.875rem;
+  position: relative;
+  border-collapse: collapse;
+  font-family: ${(props) =>
+    props.hasCodeFormat ? FONT_FAMILY.monospace : FONT_FAMILY.base};
+
+  tr:nth-child(even) {
+    background-color: ${(props) =>
+      props.hasBorder ? PALETTE.white80 : "none"};
+  }
+
+  td {
+    vertical-align: top;
+    border: ${(props) =>
+      props.hasBorder ? `solid 1px ${PALETTE.white60}` : "none"};
+    color: ${PALETTE.black60};
+    padding: ${(props) => (props.hasBorder ? "0.75rem" : "0.5rem 0")};
+  }
+
+  thead th {
+    min-width: 10rem;
+    line-height: 3;
+    vertical-align: middle;
+  }
+
+  th {
+    color: ${(props) =>
+      props.customColor ? props.customColor : PALETTE.black80};
+    text-transform: uppercase;
+    font-weight: ${FONT_WEIGHT.medium};
+    text-align: left;
+  }
+`;
+
+/**
+ * Note: This exports a React component instead of a styled-component.
+ * [Docs Table Mockup](https://zpl.io/2ZXQ0YJ) and
+ * [API Reference Table Mockup](https://zpl.io/a8JXznJ)
+ */
+
+const Table = React.forwardRef(function Table(
+  { hasCodeFormat, hasBorder, customColor, children, ...props },
+  ref,
+) {
+  return (
+    <TableEl
+      customColor={customColor}
+      hasBorder={hasBorder}
+      hasCodeFormat={hasCodeFormat}
+      ref={ref}
+      {...props}
+    >
+      {children}
+    </TableEl>
+  );
+});
+
+Table.defaultProps = {
+  hasBorder: false,
+  hasCodeFormat: false,
+};
+
+Table.propTypes = {
+  /**
+   * Table Content
+   */
+  children: PropTypes.node.isRequired,
+  /**
+   * Set to true if table includes a code snippet to change its "font-family" to "IBM Plex Mono" instead of its default "IBM Plex Sans"
+   */
+  hasCodeFormat: PropTypes.bool,
+  /**
+   * Set to true if table contains a border
+   */
+  hasBorder: PropTypes.bool,
+  /**
+   * The color of table head
+   */
+  customColor: PropTypes.string,
+};
+
+/** @component */
+export default Table;

--- a/src/components/Table.md
+++ b/src/components/Table.md
@@ -1,0 +1,167 @@
+Table with `hasBorder` props set to `true`
+
+```jsx
+<Table hasBorder>
+  <thead>
+    <tr>
+      <th>Field</th>
+      <th>Requirements</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        <span>ORG_KEYBASE</span>
+      </td>
+      <td>
+        <span>string</span>
+      </td>
+      <td>
+        <span>
+          A Keybase account name for your organization. Should contain proof of
+          ownership of any public online accounts you list here, including your
+          organization's domain.
+        </span>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <span>ORG_TWITTER</span>
+      </td>
+      <td>
+        <span>string</span>
+      </td>
+      <td>
+        <span>Your organization's Twitter account</span>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <span>ORG_GITHUB</span>
+      </td>
+      <td>
+        <span>string</span>
+      </td>
+      <td>
+        <span>Your organization's Github account</span>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <span>ORG_OFFICIAL_EMAIL</span>
+      </td>
+      <td>
+        <span>string</span>
+      </td>
+      <td>
+        <span>
+          An email where clients can contact your organization. Must be hosted
+          at your ORG_URL domain.
+        </span>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <span>ORG_LICENSING_AUTHORITY</span>
+      </td>
+      <td>
+        <span>string</span>
+      </td>
+      <td>
+        <span>
+          Name of the authority or agency that licensed your organization, if
+          applicable
+        </span>
+      </td>
+    </tr>
+  </tbody>
+</Table>
+```
+
+Table with `customColor` props set to `${PALETTE.purple}`
+
+```jsx
+import { PALETTE } from "../shared";
+
+<Table customColor={PALETTE.purple}>
+  <tr>
+    <th>
+      <span>HTTP Status Codes</span>
+    </th>
+    <td>
+      <span>Generic HTTP result codes that indicate success or failure.</span>
+    </td>
+  </tr>
+  <tr>
+    <th>
+      <span>Horizon-Specific Codes</span>
+    </th>
+    <td>
+      <span>Result codes specific to the Horizon server’s setup.</span>
+    </td>
+  </tr>
+  <tr>
+    <th>
+      <span>Transaction Codes</span>
+    </th>
+    <td>
+      <span>
+        Result codes indicating the failure reasons at the transaction level.
+      </span>
+    </td>
+  </tr>
+  <tr>
+    <th>
+      <span>Operation Codes</span>
+    </th>
+    <td>
+      <span>
+        Result codes indicating the failure reasons at the operation level.
+      </span>
+    </td>
+  </tr>
+  <tr>
+    <th>
+      <span>Operation-Specific Codes</span>
+    </th>
+    <td>
+      <span>Result codes specific to each operation type.</span>
+    </td>
+  </tr>
+</Table>;
+```
+
+Table with `hasCodeFormat` props and `customColor` props set to
+`${PALETTE.purple}`
+
+```jsx
+import { PALETTE } from "../shared";
+
+<Table customColor={PALETTE.purple} hasCodeFormat>
+  <tr>
+    <th>
+      <span>GET</span>
+    </th>
+    <td>
+      <span>/operations/:operation_id</span>
+    </td>
+  </tr>
+  <tr>
+    <th>
+      <span>GET</span>
+    </th>
+    <td>
+      <span>/operations/:operation_id/effects</span>
+    </td>
+  </tr>
+  <tr>
+    <th>
+      <span>GET</span>
+    </th>
+    <td>
+      <span>/operations{"{?cursor,limit,order,include_failed}"}</span>
+    </td>
+  </tr>
+</Table>;
+```

--- a/src/shared.js
+++ b/src/shared.js
@@ -10,14 +10,21 @@ export const FONT_WEIGHT = {
   medium: "500",
 };
 
+export const FONT_FAMILY = {
+  base: '"IBM Plex Sans", "Helvetica Neue", Arial, sans-serif',
+  monospace: '"IBM Plex Mono", Consolas, Menlo, monospace',
+};
+
 export const PALETTE = {
   white: "#ffffff",
+  white60: "#f2f2f2",
   white80: "#fafafa",
   black: "#000000",
   black30: "#999999",
   black60: "#666666",
   black80: "#333333",
-  purple: "#3e1bdb",
+  black90: "#292d3d",
+  purple: "#490be3",
 };
 
 export const SCREEN_SIZES = {

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -23,6 +23,8 @@ module.exports = {
             "src/components/BulletedList.js",
             "src/components/Button.js",
             "src/components/Card.js",
+            "src/components/CodeExample.js",
+            "src/components/Table.js",
           ],
           usageMode: "expand",
         },
@@ -50,7 +52,7 @@ module.exports = {
         {
           rel: "stylesheet",
           href: [
-            "https://fonts.googleapis.com/css?family=IBM+Plex+Sans&display=swap",
+            "https://fonts.googleapis.com/css?family=IBM+Plex+Sans:400,500&display=swap",
             "https://fonts.googleapis.com/css?family=IBM+Plex+Mono&display=swap",
           ],
         },


### PR DESCRIPTION
* `<CodeExample />` that got a header and children, which will carry one of the following: table with code related content, json, code
* `<Table/>` created with 2 types - one with borders and one without borders

Preview: https://5da8c3d160c4b60008107054--stellar-elements.netlify.com/